### PR TITLE
调整日志级别，仅为debug模式下使用

### DIFF
--- a/src/main/java/com/unfbx/chatgpt/interceptor/OpenAILogger.java
+++ b/src/main/java/com/unfbx/chatgpt/interceptor/OpenAILogger.java
@@ -13,6 +13,8 @@ import okhttp3.logging.HttpLoggingInterceptor;
 public class OpenAILogger implements HttpLoggingInterceptor.Logger {
     @Override
     public void log(String message) {
-        log.info("OkHttp-------->:{}", message);
+        if (log.isDebugEnabled()){
+            log.debug("OkHttp-------->:{}", message);
+        }
     }
 }


### PR DESCRIPTION
作为依赖包控制使用info级别太难以整合进项目中了，尤其会将key打印至日志