### PR TITLE
如果使用旧模型快照，json格式化会报错，因为有一个新字段

### DIFF
--- a/src/main/java/com/unfbx/chatgpt/entity/chat/ChatCompletionResponse.java
+++ b/src/main/java/com/unfbx/chatgpt/entity/chat/ChatCompletionResponse.java
@@ -22,4 +22,5 @@ public class ChatCompletionResponse implements Serializable {
     private String model;
     private List<ChatChoice> choices;
     private Usage usage;
+    private String warning;
 }

--- a/src/main/java/com/unfbx/chatgpt/entity/completions/CompletionResponse.java
+++ b/src/main/java/com/unfbx/chatgpt/entity/completions/CompletionResponse.java
@@ -23,4 +23,5 @@ public class CompletionResponse extends OpenAiResponse implements Serializable {
     private String model;
     private Choice[] choices;
     private Usage usage;
+    private String warning;
 }


### PR DESCRIPTION
![dc0c64aacfe5705297786ca3141f3d0](https://github.com/Grt1228/chatgpt-java/assets/68179477/c9024b4d-4317-4de7-b840-4de266d12909)
![887da375532e5b72948f699d928121d](https://github.com/Grt1228/chatgpt-java/assets/68179477/16f65992-6448-4c4d-80bb-e11106e4817f)
![487a3ae3e8991d4828fc57872d768f5](https://github.com/Grt1228/chatgpt-java/assets/68179477/8816f46e-7421-4456-b73d-619a47541179)
为什么要使用旧快照？因为论坛上普遍说0613比较蠢，而且官方同意了延长
![666898582867755f7b6b2e745012ba0](https://github.com/Grt1228/chatgpt-java/assets/68179477/23d44381-50e7-4083-8fd7-2d55e49798c4)
