### PR TITLE
修复assistant run对象Status中require_action与openai官网不符问题

### DIFF
--- a/src/main/java/com/unfbx/chatgpt/entity/assistant/run/RunResponse.java
+++ b/src/main/java/com/unfbx/chatgpt/entity/assistant/run/RunResponse.java
@@ -100,7 +100,7 @@ public class RunResponse implements Serializable {
     public enum Status {
         QUEUED("queued", "排队"),
         IN_PROGRESS("in_progress", "进行中"),
-        REQUIRE_ACTION("require_action", "需要操作"),
+        REQUIRES_ACTION("requires_action", "需要操作"),
         CANCELLING("cancelling", "取消"),
         CANCELLED("cancelled", "已取消"),
         FAILED("failed", "失败"),


### PR DESCRIPTION
如图
![image](https://github.com/Grt1228/chatgpt-java/assets/114797928/d3b4626f-c93e-4146-a885-d6b897f47305)
